### PR TITLE
[Step 2 & 3]  추천 및 독후감 기능 구현

### DIFF
--- a/src/components/form/InputField.tsx
+++ b/src/components/form/InputField.tsx
@@ -1,47 +1,53 @@
-import { type InputHTMLAttributes } from 'react';
+import { type InputHTMLAttributes, forwardRef } from 'react';
 import styled from '@emotion/styled';
 import { color } from '@/styles/colors';
 import { fontSize, fontWeight } from '@/styles/fonts';
 
-interface InputFieldProps extends InputHTMLAttributes<HTMLInputElement> {
+export interface InputFieldProps extends InputHTMLAttributes<HTMLInputElement> {
   label: string;
   id: string;
   errorMessage?: string;
   required?: boolean;
 }
 
-export default function InputField({
-  label,
-  id,
-  type = 'text',
-  placeholder,
-  value,
-  onChange,
-  errorMessage,
-  required,
-  ...props
-}: InputFieldProps) {
-  const hasError = Boolean(errorMessage);
+export default forwardRef<HTMLInputElement, InputFieldProps>(
+  function InputField(
+    {
+      label,
+      id,
+      type = 'text',
+      placeholder,
+      value,
+      onChange,
+      errorMessage,
+      required,
+      ...props
+    },
+    ref,
+  ) {
+    const hasError = Boolean(errorMessage);
 
-  return (
-    <InputFieldContainer>
-      <Label htmlFor={id}>
-        {label}
-        {required && <RequiredAsterisk>*</RequiredAsterisk>}
-      </Label>
-      <Input
-        id={id}
-        type={type}
-        placeholder={placeholder}
-        value={value}
-        onChange={onChange}
-        hasError={hasError}
-        {...props}
-      />
-      {hasError && <ErrorMessage>{errorMessage}</ErrorMessage>}
-    </InputFieldContainer>
-  );
-}
+    return (
+      <InputFieldContainer>
+        <Label htmlFor={id}>
+          {label}
+          {required && <RequiredAsterisk>*</RequiredAsterisk>}
+        </Label>
+        <Input
+          id={id}
+          type={type}
+          placeholder={placeholder}
+          value={value}
+          onChange={onChange}
+          hasError={hasError}
+          {...props}
+          ref={ref}
+        />
+        {hasError && <ErrorMessage>{errorMessage}</ErrorMessage>}
+      </InputFieldContainer>
+    );
+  },
+);
 
 const InputFieldContainer = styled.div`
   display: flex;

--- a/src/components/form/RHFCommaSeparatedInput.tsx
+++ b/src/components/form/RHFCommaSeparatedInput.tsx
@@ -1,0 +1,54 @@
+import {
+  useController,
+  UseControllerProps,
+  FieldValues,
+} from 'react-hook-form';
+import InputField, { type InputFieldProps } from '@/components/form/InputField';
+
+import { formatNumber, parseNumber } from '@/utils/number';
+
+type RHFCommaSeparatedInputProps<T extends FieldValues> = Omit<
+  InputFieldProps,
+  'value' | 'onChange' | 'onBlur' | 'name'
+> &
+  UseControllerProps<T>;
+
+export default function RHFCommaSeparatedInput<T extends FieldValues>({
+  name,
+  control,
+  rules,
+  defaultValue,
+  ...props
+}: RHFCommaSeparatedInputProps<T>) {
+  const {
+    field: { onChange, onBlur, value, ref },
+    fieldState: { error },
+  } = useController({
+    name,
+    control,
+    rules,
+    defaultValue,
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const rawValue = e.target.value;
+
+    if (/^[0-9,]*$/.test(rawValue)) {
+      const numericValue = parseNumber(rawValue);
+      onChange(numericValue === undefined ? undefined : numericValue);
+    }
+  };
+
+  return (
+    <InputField
+      {...props}
+      ref={ref}
+      value={formatNumber(value)}
+      onChange={handleChange}
+      onBlur={onBlur}
+      errorMessage={error?.message}
+      type="text"
+      inputMode="numeric"
+    />
+  );
+}

--- a/src/components/form/steps/BookInfoStep.tsx
+++ b/src/components/form/steps/BookInfoStep.tsx
@@ -5,22 +5,35 @@ import Alert from '@/components/ui/Alert';
 import Icon from '@/components/ui/Icon';
 import styled from '@emotion/styled';
 import { type BookFormSchema } from '@/utils/schema';
-import { READING_STATUS, READING_STATUS_OPTIONS } from '@/constants/book';
+import {
+  READING_STATUS_OPTIONS,
+  BOOK_FORM_STEPS,
+  READING_STATUS,
+} from '@/constants/book';
 import AlertTriangleIcon from '@/assets/icons/alert-triangle.svg';
+
+const STATUS_REQUIRED_POLICY = {
+  [READING_STATUS.WISH]: { startDate: false, endDate: false },
+  [READING_STATUS.READING]: { startDate: true, endDate: false },
+  [READING_STATUS.DONE]: { startDate: true, endDate: true },
+  [READING_STATUS.PAUSE]: { startDate: true, endDate: false },
+} as const;
 
 export default function BookInfoStep() {
   const {
     register,
-    watch,
     control,
+    watch,
     formState: { errors },
   } = useFormContext<BookFormSchema>();
 
   const status = watch('status');
-  const shouldShowStartDate = status && status !== READING_STATUS.WISH;
-  const shouldShowEndDate = status === READING_STATUS.DONE;
+  const { startDate: isStartDateRequired, endDate: isEndDateRequired } =
+    STATUS_REQUIRED_POLICY[status];
 
-  const hasErrors = Object.keys(errors).length > 0;
+  const hasErrors = BOOK_FORM_STEPS.BOOK_INFO.fields.some(
+    (field) => errors[field],
+  );
 
   return (
     <Container>
@@ -59,7 +72,6 @@ export default function BookInfoStep() {
           type="date"
           {...register('publishedDate')}
           errorMessage={errors.publishedDate?.message}
-          required
         />
 
         {/* TODO: 3.6 요구사항에 따라 RHFCommaSeparatedInput 컴포넌트 사용 */}
@@ -93,26 +105,22 @@ export default function BookInfoStep() {
       />
 
       <GridContainer>
-        {shouldShowStartDate && (
-          <InputField
-            id="startDate"
-            label="독서 시작일"
-            type="date"
-            {...register('startDate')}
-            errorMessage={errors.startDate?.message}
-            required
-          />
-        )}
-        {shouldShowEndDate && (
-          <InputField
-            id="endDate"
-            label="독서 종료일"
-            type="date"
-            {...register('endDate')}
-            errorMessage={errors.endDate?.message}
-            required
-          />
-        )}
+        <InputField
+          id="startDate"
+          label="독서 시작일"
+          type="date"
+          {...register('startDate')}
+          errorMessage={errors.startDate?.message}
+          required={isStartDateRequired}
+        />
+        <InputField
+          id="endDate"
+          label="독서 종료일"
+          type="date"
+          {...register('endDate')}
+          errorMessage={errors.endDate?.message}
+          required={isEndDateRequired}
+        />
       </GridContainer>
     </Container>
   );

--- a/src/components/form/steps/BookInfoStep.tsx
+++ b/src/components/form/steps/BookInfoStep.tsx
@@ -5,11 +5,8 @@ import Alert from '@/components/ui/Alert';
 import Icon from '@/components/ui/Icon';
 import styled from '@emotion/styled';
 import { type BookFormSchema } from '@/utils/schema';
-import {
-  READING_STATUS_OPTIONS,
-  BOOK_FORM_STEPS,
-  READING_STATUS,
-} from '@/constants/book';
+import { READING_STATUS_OPTIONS, READING_STATUS } from '@/constants/book';
+import { BOOK_FORM_STEPS } from '@/constants/form';
 import AlertTriangleIcon from '@/assets/icons/alert-triangle.svg';
 
 const STATUS_REQUIRED_POLICY = {

--- a/src/components/form/steps/BookInfoStep.tsx
+++ b/src/components/form/steps/BookInfoStep.tsx
@@ -73,6 +73,7 @@ export default function BookInfoStep() {
         />
 
         <RHFCommaSeparatedInput
+          id="totalPages"
           name="totalPages"
           control={control}
           label="전체 페이지 수"

--- a/src/components/form/steps/BookInfoStep.tsx
+++ b/src/components/form/steps/BookInfoStep.tsx
@@ -1,5 +1,6 @@
 import { useFormContext, Controller } from 'react-hook-form';
 import InputField from '@/components/form/InputField';
+import RHFCommaSeparatedInput from '@/components/form/RHFCommaSeparatedInput';
 import Select from '@/components/form/Select';
 import Alert from '@/components/ui/Alert';
 import Icon from '@/components/ui/Icon';
@@ -71,13 +72,10 @@ export default function BookInfoStep() {
           errorMessage={errors.publishedDate?.message}
         />
 
-        {/* TODO: 3.6 요구사항에 따라 RHFCommaSeparatedInput 컴포넌트 사용 */}
-        <InputField
-          id="totalPages"
+        <RHFCommaSeparatedInput
+          name="totalPages"
+          control={control}
           label="전체 페이지 수"
-          type="number"
-          {...register('totalPages')}
-          errorMessage={errors.totalPages?.message}
           placeholder="숫자를 입력해주세요"
           required
         />

--- a/src/components/form/steps/RatingStep.tsx
+++ b/src/components/form/steps/RatingStep.tsx
@@ -1,0 +1,126 @@
+import { useFormContext, Controller } from 'react-hook-form';
+import { RadioGroup, RadioItem } from '@/components/form/Radio';
+import Ratings from '@/components/ui/Ratings';
+import Alert from '@/components/ui/Alert';
+import Icon from '@/components/ui/Icon';
+import styled from '@emotion/styled';
+import { type BookFormSchema } from '@/utils/schema';
+import { BOOK_FORM_STEPS } from '@/constants/form';
+import { color } from '@/styles/colors';
+import { fontSize, fontWeight } from '@/styles/fonts';
+import AlertTriangleIcon from '@/assets/icons/alert-triangle.svg';
+
+export default function RatingStep() {
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext<BookFormSchema>();
+
+  const hasErrors = BOOK_FORM_STEPS.RATING.fields.some(
+    (field) => errors[field],
+  );
+
+  return (
+    <Container>
+      {hasErrors && (
+        <Alert
+          variant="error"
+          title="입력 정보를 확인해주세요"
+          description="추천 여부와 별점을 모두 선택해주세요."
+          icon={<Icon as={AlertTriangleIcon} size={20} />}
+        />
+      )}
+
+      <FieldContainer>
+        <Controller
+          name="recommend"
+          control={control}
+          render={({ field }) => (
+            <RadioGroup
+              name="recommend"
+              value={field.value ? 'yes' : 'no'}
+              onChange={(value) => field.onChange(value === 'yes')}
+              label="이 책을 추천하시겠어요?"
+              errorMessage={errors.recommend?.message}
+            >
+              <RadioItem value="yes" label="예" />
+              <RadioItem value="no" label="아니오" />
+            </RadioGroup>
+          )}
+        />
+      </FieldContainer>
+
+      <FieldContainer>
+        <Controller
+          name="rating"
+          control={control}
+          render={({ field }) => (
+            <RatingContainer>
+              <RatingLabel hasError={hasErrors}>
+                별점을 선택해주세요 <RequiredMark>*</RequiredMark>
+              </RatingLabel>
+              <RatingWrapper>
+                <Ratings
+                  rating={field.value}
+                  onChange={field.onChange}
+                  size={32}
+                  variant={hasErrors ? 'error' : 'yellow'}
+                />
+                <RatingText>{field.value}점</RatingText>
+              </RatingWrapper>
+              {errors.rating && (
+                <ErrorMessage>{errors.rating.message}</ErrorMessage>
+              )}
+            </RatingContainer>
+          )}
+        />
+      </FieldContainer>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+`;
+
+const FieldContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const RatingContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+`;
+
+const RatingLabel = styled.label<{ hasError?: boolean }>`
+  font-size: ${fontSize.sm};
+  font-weight: ${fontWeight.medium};
+  color: ${({ hasError }) => (hasError ? color.red500 : color.gray700)};
+`;
+
+const RequiredMark = styled.span`
+  color: ${color.red500};
+`;
+
+const RatingWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+`;
+
+const RatingText = styled.span`
+  font-size: ${fontSize.lg};
+  font-weight: ${fontWeight.medium};
+  color: ${color.gray700};
+  min-width: 3rem;
+`;
+
+const ErrorMessage = styled.p`
+  font-size: ${fontSize.sm};
+  color: ${color.red500};
+  margin: 0;
+`;

--- a/src/components/form/steps/ReviewStep.tsx
+++ b/src/components/form/steps/ReviewStep.tsx
@@ -1,0 +1,121 @@
+import { useFormContext, Controller } from 'react-hook-form';
+import TextArea from '@/components/ui/TextArea';
+import Alert from '@/components/ui/Alert';
+import Icon from '@/components/ui/Icon';
+import styled from '@emotion/styled';
+import { type BookFormSchema } from '@/utils/schema';
+import { BOOK_FORM_STEPS } from '@/constants/form';
+import { color } from '@/styles/colors';
+import { fontSize, fontWeight } from '@/styles/fonts';
+import AlertTriangleIcon from '@/assets/icons/alert-triangle.svg';
+
+export default function ReviewStep() {
+  const {
+    control,
+    watch,
+    formState: { errors },
+  } = useFormContext<BookFormSchema>();
+
+  const rating = watch('rating');
+  const review = watch('review');
+  const isReviewRequired = rating === 1 || rating === 5;
+  const reviewCharCount = review?.length || 0;
+
+  const hasErrors = BOOK_FORM_STEPS.REVIEW.fields.some(
+    (field) => errors[field],
+  );
+
+  return (
+    <Container>
+      {hasErrors && (
+        <Alert
+          variant="error"
+          title="입력 정보를 확인해주세요"
+          description="독후감을 입력해주세요."
+          icon={<Icon as={AlertTriangleIcon} size={20} />}
+        />
+      )}
+
+      <FieldContainer>
+        <Controller
+          name="review"
+          control={control}
+          render={({ field }) => (
+            <ReviewContainer>
+              <ReviewLabelContainer>
+                <ReviewLabel hasError={hasErrors}>
+                  이 책에 대한 독후감을 작성해주세요
+                  {isReviewRequired && <RequiredMark>*</RequiredMark>}
+                </ReviewLabel>
+                <CharCount isError={isReviewRequired && reviewCharCount < 100}>
+                  {reviewCharCount}
+                  {isReviewRequired && '/100'}자
+                </CharCount>
+              </ReviewLabelContainer>
+
+              <TextArea
+                {...field}
+                placeholder={
+                  isReviewRequired
+                    ? '별점이 1점 또는 5점인 경우 독후감을 100자 이상 작성해주세요.'
+                    : '이 책에 대한 독후감을 자유롭게 작성해주세요.'
+                }
+                rows={8}
+                hasError={hasErrors}
+              />
+
+              {errors.review && (
+                <ErrorMessage>{errors.review.message}</ErrorMessage>
+              )}
+            </ReviewContainer>
+          )}
+        />
+      </FieldContainer>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+`;
+
+const FieldContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const ReviewContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+`;
+
+const ReviewLabelContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const ReviewLabel = styled.label<{ hasError?: boolean }>`
+  font-size: ${fontSize.sm};
+  font-weight: ${fontWeight.medium};
+  color: ${({ hasError }) => (hasError ? color.red500 : color.gray700)};
+`;
+
+const RequiredMark = styled.span`
+  color: ${color.red500};
+`;
+
+const CharCount = styled.span<{ isError?: boolean }>`
+  font-size: ${fontSize.sm};
+  color: ${({ isError }) => (isError ? color.red500 : color.gray500)};
+  font-weight: ${fontWeight.medium};
+`;
+
+const ErrorMessage = styled.p`
+  font-size: ${fontSize.sm};
+  color: ${color.red500};
+  margin: 0;
+`;

--- a/src/components/preview/AppPreview.tsx
+++ b/src/components/preview/AppPreview.tsx
@@ -30,12 +30,14 @@ interface AppPreviewProps {
 export function AppPreview({ bookInfo }: AppPreviewProps) {
   const debouncedBookInfo = useDebounce(bookInfo, PREVIEW_DEBOUNCE_DELAY_MS);
 
-  const { startDate, endDate, isPublic = false } = debouncedBookInfo;
-
-  // TODO: 실제 데이터에서 가져오도록 수정 필요
-  const recommend = true;
-  const rating = 5;
-  const review = '독후감을 작성해주세요...';
+  const {
+    startDate,
+    endDate,
+    isPublic = false,
+    recommend,
+    rating,
+    review,
+  } = debouncedBookInfo;
 
   return (
     <PreviewContainer>

--- a/src/components/preview/sections/DateSection.tsx
+++ b/src/components/preview/sections/DateSection.tsx
@@ -8,8 +8,8 @@ import { Section, SectionTitle } from '@/components/preview/styles/shared';
 import { formatKoreanShortDate } from '@/utils/date';
 
 interface DateSectionProps {
-  startDate?: Date | null;
-  endDate?: Date | null;
+  startDate?: string | null;
+  endDate?: string | null;
 }
 
 export function DateSection({ startDate, endDate }: DateSectionProps) {

--- a/src/components/ui/TextArea.tsx
+++ b/src/components/ui/TextArea.tsx
@@ -1,0 +1,48 @@
+import styled from '@emotion/styled';
+import { color } from '@/styles/colors';
+import { fontSize } from '@/styles/fonts';
+import { ComponentProps, forwardRef } from 'react';
+
+interface TextAreaProps extends ComponentProps<'textarea'> {
+  hasError?: boolean;
+}
+
+const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
+  ({ hasError, ...props }, ref) => {
+    return <StyledTextArea ref={ref} hasError={hasError} {...props} />;
+  },
+);
+
+TextArea.displayName = 'TextArea';
+
+export default TextArea;
+
+const StyledTextArea = styled.textarea<{ hasError?: boolean }>`
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid
+    ${({ hasError }) => (hasError ? color.red500 : color.gray300)};
+  border-radius: 0.375rem;
+  font-size: ${fontSize.sm};
+  line-height: 1.5;
+  resize: vertical;
+  min-height: 120px;
+
+  &:focus {
+    outline: none;
+    border-color: ${({ hasError }) =>
+      hasError ? color.red500 : color.blue500};
+    box-shadow: 0 0 0 1px
+      ${({ hasError }) => (hasError ? color.red500 : color.blue500)};
+  }
+
+  &::placeholder {
+    color: ${color.gray400};
+  }
+
+  &:disabled {
+    background-color: ${color.gray50};
+    color: ${color.gray400};
+    cursor: not-allowed;
+  }
+`;

--- a/src/constants/book.ts
+++ b/src/constants/book.ts
@@ -1,3 +1,5 @@
+import { BookFormSchema } from '@/utils/schema';
+
 export const READING_STATUS = {
   WISH: 'WISH' as const,
   READING: 'READING' as const,
@@ -28,10 +30,38 @@ export const READING_STATUS_LABELS = {
   [READING_STATUS.PAUSE]: '보류 중',
 } as const;
 
-export const BOOK_FORM_STEPS = [
-  '도서 정보',
-  '추천 & 별점',
-  '독후감',
-  '인용구',
-  '공개 설정',
-];
+export const BOOK_FORM_STEPS = {
+  BOOK_INFO: {
+    order: 1,
+    label: '도서 정보',
+    fields: [
+      'title',
+      'author',
+      'publishedDate',
+      'totalPages',
+      'status',
+      'startDate',
+      'endDate',
+    ] as (keyof BookFormSchema)[],
+  },
+  RATING: {
+    order: 2,
+    label: '추천 & 별점',
+    fields: ['recommend', 'rating'] as (keyof BookFormSchema)[],
+  },
+  REVIEW: {
+    order: 3,
+    label: '독후감',
+    fields: ['review'] as (keyof BookFormSchema)[],
+  },
+  QUOTES: {
+    order: 4,
+    label: '인용구',
+    fields: ['quotes'] as (keyof BookFormSchema)[],
+  },
+  PUBLIC: {
+    order: 5,
+    label: '공개 설정',
+    fields: ['isPublic'] as (keyof BookFormSchema)[],
+  },
+} as const;

--- a/src/constants/book.ts
+++ b/src/constants/book.ts
@@ -1,5 +1,3 @@
-import { BookFormSchema } from '@/utils/schema';
-
 export const READING_STATUS = {
   WISH: 'WISH' as const,
   READING: 'READING' as const,
@@ -28,40 +26,4 @@ export const READING_STATUS_LABELS = {
   [READING_STATUS.READING]: '읽는 중',
   [READING_STATUS.DONE]: '읽음',
   [READING_STATUS.PAUSE]: '보류 중',
-} as const;
-
-export const BOOK_FORM_STEPS = {
-  BOOK_INFO: {
-    order: 1,
-    label: '도서 정보',
-    fields: [
-      'title',
-      'author',
-      'publishedDate',
-      'totalPages',
-      'status',
-      'startDate',
-      'endDate',
-    ] as (keyof BookFormSchema)[],
-  },
-  RATING: {
-    order: 2,
-    label: '추천 & 별점',
-    fields: ['recommend', 'rating'] as (keyof BookFormSchema)[],
-  },
-  REVIEW: {
-    order: 3,
-    label: '독후감',
-    fields: ['review'] as (keyof BookFormSchema)[],
-  },
-  QUOTES: {
-    order: 4,
-    label: '인용구',
-    fields: ['quotes'] as (keyof BookFormSchema)[],
-  },
-  PUBLIC: {
-    order: 5,
-    label: '공개 설정',
-    fields: ['isPublic'] as (keyof BookFormSchema)[],
-  },
 } as const;

--- a/src/constants/form.ts
+++ b/src/constants/form.ts
@@ -1,0 +1,44 @@
+import BookInfoStep from '@/components/form/steps/BookInfoStep';
+import RatingStep from '@/components/form/steps/RatingStep';
+import ReviewStep from '@/components/form/steps/ReviewStep';
+
+export const BOOK_FORM_STEPS = {
+  BOOK_INFO: {
+    order: 1,
+    label: '도서 정보',
+    fields: [
+      'title',
+      'author',
+      'publishedDate',
+      'totalPages',
+      'status',
+      'startDate',
+      'endDate',
+    ],
+    component: BookInfoStep,
+  },
+  RATING: {
+    order: 2,
+    label: '추천 & 별점',
+    fields: ['recommend', 'rating'],
+    component: RatingStep,
+  },
+  REVIEW: {
+    order: 3,
+    label: '독후감',
+    fields: ['review'],
+    component: ReviewStep,
+  },
+  QUOTES: {
+    order: 4,
+    label: '인용구',
+    fields: ['quotes'],
+    component: ReviewStep, // FIXME: QuoteStep으로 교체 필요
+  },
+  PUBLIC: {
+    order: 5,
+    label: '공개 설정',
+    fields: ['isPublic'],
+    component: ReviewStep, // FIXME: PublicStep으로 교체 필요
+  },
+} as const;

--- a/src/constants/localStorage.ts
+++ b/src/constants/localStorage.ts
@@ -1,0 +1,10 @@
+export const LOCAL_STORAGE_KEYS = {
+  MULTI_STEP_FORM_DATA: 'multi-step-form-data',
+} as const;
+
+export type LocalStorageKey =
+  (typeof LOCAL_STORAGE_KEYS)[keyof typeof LOCAL_STORAGE_KEYS];
+
+export interface LocalStorageValueMap {
+  [LOCAL_STORAGE_KEYS.MULTI_STEP_FORM_DATA]: Record<string, unknown>;
+}

--- a/src/hooks/useFormPersistence.ts
+++ b/src/hooks/useFormPersistence.ts
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+import { FieldValues, UseFormReturn } from 'react-hook-form';
+import { useDebounce } from '@/hooks/useDebounce';
+import { localStorageManager } from '@/utils/localStorageManager';
+import { LocalStorageKey } from '@/constants/localStorage';
+
+/**
+ * react-hook-form의 상태를 localStorage에 자동으로 저장하고 복원합니다.
+ * 이 훅은 범용적으로 설계되어 어떤 폼, 어떤 키와도 함께 사용할 수 있습니다.
+ * @param methods useForm에서 반환된 객체
+ * @param persistenceKey localStorage에 저장할 때 사용할 키
+ */
+export default function useFormPersistence<T extends FieldValues>(
+  methods: UseFormReturn<T>,
+  persistenceKey: LocalStorageKey,
+) {
+  const watchedData = methods.watch();
+  const debouncedData = useDebounce(watchedData, 500);
+
+  useEffect(() => {
+    const savedData = localStorageManager.getItem(persistenceKey);
+    if (savedData) {
+      methods.reset(savedData as T, { keepDirty: false });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!methods.formState.isDirty) {
+      return;
+    }
+    localStorageManager.setItem(persistenceKey, debouncedData);
+  }, [debouncedData, methods.formState.isDirty]);
+
+  const clearStoredData = () => {
+    localStorageManager.removeItem(persistenceKey);
+  };
+
+  return { clearStoredData };
+}

--- a/src/hooks/useStepForm.ts
+++ b/src/hooks/useStepForm.ts
@@ -1,0 +1,111 @@
+import { ComponentType, useEffect } from 'react';
+import { FieldValues, Path, UseFormReturn } from 'react-hook-form';
+import { useRouter } from 'next/router';
+
+export interface StepConfig<T extends FieldValues> {
+  readonly order: number;
+  readonly label: string;
+  readonly fields: readonly Path<T>[];
+  readonly component: ComponentType;
+}
+
+export interface StepFormReturn<T extends FieldValues> {
+  readonly currentStepIndex: number;
+  readonly currentStep: StepConfig<T>;
+  readonly isFirstStep: boolean;
+  readonly isLastStep: boolean;
+  readonly handleNext: () => Promise<void>;
+  readonly handleBack: () => void;
+  readonly handleReset: () => void;
+  readonly steps: StepConfig<T>[];
+}
+
+export function useStepForm<T extends FieldValues>(
+  stepDefinitions: Record<string, StepConfig<T>>,
+  methods: UseFormReturn<T>,
+  onSubmit: (data: T) => void | Promise<void>,
+): StepFormReturn<T> {
+  const router = useRouter();
+  const { isReady, query } = router;
+
+  const steps = Object.values(stepDefinitions).sort(
+    (a, b) => a.order - b.order,
+  );
+  const stepCount = steps.length;
+
+  const getStepIndex = () => {
+    if (!isReady) return 0;
+    const step = Number(query.step);
+    if (isNaN(step) || step < 1 || step > stepCount) return 0;
+    return step - 1;
+  };
+
+  const currentStepIndex = getStepIndex();
+  const currentStep = steps[currentStepIndex];
+  const isFirstStep = currentStepIndex === 0;
+  const isLastStep = currentStepIndex === stepCount - 1;
+
+  const navigateToStep = (stepNumber: number, replace = false) => {
+    const method = replace ? router.replace : router.push;
+    method(`?step=${stepNumber}`, undefined, { shallow: true });
+  };
+
+  useEffect(() => {
+    if (!isReady) return;
+
+    const step = Number(query.step);
+
+    if (isNaN(step) || step < 1 || step > stepCount) {
+      navigateToStep(1, true);
+    }
+  }, [isReady, query, stepCount, router]);
+
+  const handleNext = async () => {
+    if (!currentStep) return;
+
+    try {
+      const { fields } = currentStep;
+      const isValid = await methods.trigger(fields);
+
+      if (!isValid) {
+        const firstErrorField = fields.find(
+          (field) => methods.formState.errors[field],
+        );
+        if (firstErrorField) {
+          methods.setFocus(firstErrorField as Path<T>);
+        }
+        return;
+      }
+
+      if (isLastStep) {
+        await methods.handleSubmit(onSubmit)();
+      } else {
+        navigateToStep(currentStepIndex + 2);
+      }
+    } catch (error) {
+      console.error('Step navigation failed:', error);
+    }
+  };
+
+  const handleBack = () => {
+    if (isFirstStep) return;
+
+    navigateToStep(currentStepIndex);
+  };
+
+  const handleReset = () => {
+    navigateToStep(1);
+    methods.reset();
+  };
+
+  return {
+    currentStepIndex,
+    currentStep,
+    isFirstStep,
+    isLastStep,
+    handleNext,
+    handleBack,
+    handleReset,
+    steps,
+  };
+}

--- a/src/hooks/useUrlStep.ts
+++ b/src/hooks/useUrlStep.ts
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+interface UseUrlStepOptions {
+  /** URL 쿼리 파라미터로 사용할 이름입니다. 기본값은 'step'입니다. */
+  paramName?: string;
+}
+
+/**
+ * URL 쿼리 파라미터를 기반으로 멀티스텝 UI의 현재 스텝을 관리합니다.
+ * 이 훅은 범용적으로 설계되어 어떤 이름의 쿼리 파라미터와도 함께 사용할 수 있습니다.
+ * @param totalSteps 전체 스텝의 수
+ * @param options 추가 옵션 (예: { paramName: 'tab' })
+ */
+export default function useUrlStep(
+  totalSteps: number,
+  options?: UseUrlStepOptions,
+) {
+  const router = useRouter();
+  const { isReady, query } = router;
+  const paramName = options?.paramName ?? 'step';
+
+  const navigateToStep = (stepNumber: number, replace = false) => {
+    const method = replace ? router.replace : router.push;
+    method({ query: { ...query, [paramName]: stepNumber } }, undefined, {
+      shallow: true,
+    });
+  };
+
+  const getStepIndex = () => {
+    if (!isReady) {
+      return 0;
+    }
+    const step = Number(query[paramName]);
+    if (isNaN(step) || step < 1 || step > totalSteps) {
+      return 0;
+    }
+    return step - 1;
+  };
+
+  const currentStepIndex = getStepIndex();
+  useEffect(() => {
+    if (!isReady) {
+      return;
+    }
+    const step = Number(query[paramName]);
+    if (isNaN(step) || step < 1 || step > totalSteps) {
+      navigateToStep(1, true);
+    }
+  }, [isReady, query, totalSteps, paramName]);
+
+  const isFirstStep = currentStepIndex === 0;
+  const isLastStep = currentStepIndex === totalSteps - 1;
+
+  return { currentStepIndex, navigateToStep, isFirstStep, isLastStep };
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -17,7 +17,8 @@ import {
   DESKTOP_MIN_WIDTH,
   useIsAboveMinWidth,
 } from '@/hooks/useIsAboveMinWidth';
-import { useStepForm } from '@/hooks/useStepForm';
+import useStepForm from '@/hooks/useStepForm';
+import { LOCAL_STORAGE_KEYS } from '@/constants/localStorage';
 
 export default function HomePage() {
   const isDesktop = useIsAboveMinWidth(DESKTOP_MIN_WIDTH);
@@ -46,7 +47,13 @@ export default function HomePage() {
     handleBack,
     handleReset,
     steps,
-  } = useStepForm<BookFormSchema>(BOOK_FORM_STEPS, methods, onSubmit);
+  } = useStepForm<BookFormSchema>(
+    BOOK_FORM_STEPS,
+    methods,
+    onSubmit,
+    BOOK_FORM_DEFAULT_VALUES,
+    { persistenceKey: LOCAL_STORAGE_KEYS.MULTI_STEP_FORM_DATA },
+  );
 
   const CurrentStepComponent = currentStep?.component;
 

--- a/src/utils/localStorageManager.ts
+++ b/src/utils/localStorageManager.ts
@@ -1,0 +1,105 @@
+import {
+  LocalStorageKey,
+  LocalStorageValueMap,
+} from '@/constants/localStorage';
+
+const isBrowser = typeof window !== 'undefined';
+
+interface LocalStorageManager {
+  setItem<K extends LocalStorageKey>(
+    key: K,
+    value: LocalStorageValueMap[K],
+  ): void;
+  getItem<K extends LocalStorageKey>(key: K): LocalStorageValueMap[K] | null;
+  removeItem(key: LocalStorageKey): void;
+  clear(except?: LocalStorageKey[]): void;
+}
+
+/**
+ * localStorage를 안전하고 편리하게 관리하기 위한 객체입니다.
+ * - 서버 사이드 렌더링(SSR) 환경을 고려하여 브라우저에서만 동작합니다!
+ * - key와 value 타입을 미리 정의하여 타입 안정성을 보장합니다. (`LocalStorageKey`, `LocalStorageValueMap`)
+ * - JSON 파싱/직렬화 과정에서 발생할 수 있는 오류를 처리합니다.
+ */
+export const localStorageManager: LocalStorageManager = {
+  /**
+   * 지정된 key와 value를 localStorage에 저장합니다.
+   * (주의) value는 JSON 문자열로 변환되어 저장됩니다!
+   * @template K - LocalStorage의 key 타입
+   * @param {K} key - 저장할 데이터의 key
+   * @param {LocalStorageValueMap[K]} value - 저장할 데이터의 값
+   */
+  setItem(key, value) {
+    if (!isBrowser) return;
+
+    try {
+      const stringValue = JSON.stringify(value);
+      localStorage.setItem(key, stringValue);
+    } catch (error) {
+      console.error(
+        `[LocalStorageManager] Error setting item "${key}":`,
+        error,
+      );
+    }
+  },
+
+  /**
+   * localStorage에서 지정된 key에 해당하는 값을 가져옵니다.
+   * (주의) 값은 JSON 파싱을 거쳐 원래 타입으로 변환됩니다.
+   * @template K - LocalStorage의 key 타입
+   * @param {K} key - 가져올 데이터의 key
+   * @returns {LocalStorageValueMap[K] | null} - key에 해당하는 값 또는 값이 없거나 오류 발생 시 null
+   */
+  getItem(key) {
+    if (!isBrowser) return null;
+
+    try {
+      const stringValue = localStorage.getItem(key);
+      if (stringValue === null) {
+        return null;
+      }
+      return JSON.parse(stringValue) as LocalStorageValueMap[typeof key];
+    } catch (error) {
+      console.error(
+        `[LocalStorageManager] Error getting item "${key}":`,
+        error,
+      );
+      this.removeItem(key);
+      return null;
+    }
+  },
+
+  /**
+   * localStorage에서 지정된 key의 아이템을 삭제합니다.
+   * @param {LocalStorageKey} key - 삭제할 데이터의 key
+   */
+  removeItem(key) {
+    if (!isBrowser) return;
+
+    try {
+      localStorage.removeItem(key);
+    } catch (error) {
+      console.error(
+        `[LocalStorageManager] Error removing item "${key}":`,
+        error,
+      );
+    }
+  },
+
+  /**
+   * localStorage의 모든 데이터를 삭제합니다.
+   * (주의) 'except' 배열에 포함된 key들은 삭제되지 않습니다.
+   * @param {LocalStorageKey[]} [except=[]] - 삭제에서 제외할 key들의 배열
+   */
+  clear(except: LocalStorageKey[] = []) {
+    if (!isBrowser) return;
+
+    const localStorageKeys = Object.keys(localStorage) as LocalStorageKey[];
+
+    localStorageKeys.forEach((key) => {
+      if (!except.includes(key)) {
+        this.removeItem(key);
+      }
+    });
+  },
+};

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -1,0 +1,23 @@
+export const formatNumber = (
+  value: number | string | null | undefined,
+): string => {
+  if (
+    value === '' ||
+    value === null ||
+    value === undefined ||
+    isNaN(Number(value))
+  ) {
+    return '';
+  }
+
+  const num =
+    typeof value === 'string' ? parseFloat(value.replace(/,/g, '')) : value;
+
+  return new Intl.NumberFormat('ko-KR').format(num);
+};
+
+export const parseNumber = (value: string): number | undefined => {
+  const parsed = parseInt(value.replace(/,/g, ''), 10);
+
+  return isNaN(parsed) ? undefined : parsed;
+};

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -31,7 +31,8 @@ export const bookFormSchema = z
       .number({
         invalid_type_error: '숫자를 입력해주세요.',
       })
-      .min(1, { message: '1 이상의 숫자를 입력해주세요.' }),
+      .min(1, { message: '1 이상의 숫자를 입력해주세요.' })
+      .optional(),
     status: z.enum(READING_STATUS_VALUES, {
       errorMap: () => ({ message: '독서 상태를 선택해주세요.' }),
     }),
@@ -44,7 +45,23 @@ export const bookFormSchema = z
     isPublic: z.boolean().optional(),
   })
   .superRefine((data, ctx) => {
-    const { status, startDate, endDate, publishedDate, rating, review } = data;
+    const {
+      status,
+      startDate,
+      endDate,
+      publishedDate,
+      rating,
+      review,
+      totalPages,
+    } = data;
+
+    if (totalPages === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: '전체 페이지 수를 입력해주세요.',
+        path: ['totalPages'],
+      });
+    }
 
     if (status === READING_STATUS.WISH) {
       if (startDate) {
@@ -121,7 +138,6 @@ export const bookFormSchema = z
       }
     }
 
-    // PRD: 별점이 1점 또는 5점일 경우: 독후감 100자 이상 필수
     if ((rating === 1 || rating === 5) && (!review || review.length < 100)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -42,7 +42,7 @@ export const bookFormSchema = z
     isPublic: z.boolean().optional(),
   })
   .superRefine((data, ctx) => {
-    const { status, startDate, endDate, publishedDate } = data;
+    const { status, startDate, endDate, publishedDate, rating, review } = data;
 
     if (status === READING_STATUS.WISH) {
       if (startDate) {
@@ -117,5 +117,14 @@ export const bookFormSchema = z
           path: ['startDate'],
         });
       }
+    }
+
+    // PRD: 별점이 1점 또는 5점일 경우: 독후감 100자 이상 필수
+    if ((rating === 1 || rating === 5) && (!review || review.length < 100)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: '별점이 1점 또는 5점인 경우 독후감을 100자 이상 입력해주세요.',
+        path: ['review'],
+      });
     }
   });

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -1,70 +1,121 @@
 import { z } from 'zod';
-import { isAfterOrSameDate } from './date';
+import { isAfterDate, isAfterOrSameDate } from './date';
 import { READING_STATUS_VALUES, READING_STATUS } from '@/constants/book';
+
+export type BookFormSchema = z.infer<typeof bookFormSchema>;
+export const BOOK_FORM_DEFAULT_VALUES = {
+  title: '',
+  author: '',
+  publishedDate: '',
+  totalPages: 0,
+  status: READING_STATUS.WISH,
+  startDate: null,
+  endDate: null,
+  recommend: false,
+  rating: 0,
+  review: '',
+  quotes: [],
+  isPublic: false,
+} satisfies z.input<typeof bookFormSchema>;
+
+const dateSchema = z.string().refine((val) => !isNaN(Date.parse(val)), {
+  message: '유효한 날짜 형식이 아닙니다.',
+});
 
 export const bookFormSchema = z
   .object({
     title: z.string().min(1, { message: '도서명을 입력해주세요.' }),
     author: z.string().min(1, { message: '저자명을 입력해주세요.' }),
-    publishedDate: z.coerce
-      .date({
-        errorMap: () => ({ message: '유효한 날짜 형식이 아닙니다.' }),
-      })
-      .min(new Date('1900-01-01'), {
-        message: '1900년 이후의 날짜를 입력해주세요.',
-      })
-      .max(new Date(), { message: '오늘 이전의 날짜를 입력해주세요.' }),
+    publishedDate: dateSchema,
     totalPages: z.coerce
       .number()
       .min(1, { message: '전체 페이지 수를 입력해주세요.' }),
     status: z.enum(READING_STATUS_VALUES, {
       errorMap: () => ({ message: '독서 상태를 선택해주세요.' }),
     }),
-    startDate: z.coerce
-      .date({
-        errorMap: () => ({ message: '유효한 날짜 형식이 아닙니다.' }),
-      })
-      .min(new Date('1900-01-01'), {
-        message: '1900년 이후의 날짜를 입력해주세요.',
-      })
-      .max(new Date(), { message: '오늘 이전의 날짜를 입력해주세요.' }),
-    endDate: z.coerce
-      .date({
-        errorMap: () => ({ message: '유효한 날짜 형식이 아닙니다.' }),
-      })
-      .min(new Date('1900-01-01'), {
-        message: '1900년 이후의 날짜를 입력해주세요.',
-      })
-      .max(new Date(), { message: '오늘 이전의 날짜를 입력해주세요.' }),
-    // Step 2~5 단계 임시 스키마 (Todo: 각 단계 구현시 재정의 필요)
-    recommend: z.boolean().optional(),
-    rating: z.number().min(0).max(5).optional(),
+    startDate: z.string().nullable().optional(),
+    endDate: z.string().nullable().optional(),
+    recommend: z.boolean({ required_error: '추천 여부를 선택해주세요.' }),
+    rating: z.number().min(0.5, { message: '별점을 선택해주세요.' }).max(5),
     review: z.string().optional(),
     quotes: z.array(z.string()).optional(),
     isPublic: z.boolean().optional(),
   })
-  .refine((data) => isAfterOrSameDate(data.startDate, data.publishedDate), {
-    message: '독서 시작일은 출판일보다 빠를 수 없습니다.',
-    path: ['startDate'],
-  })
-  .refine((data) => isAfterOrSameDate(data.endDate, data.startDate), {
-    message: '독서 종료일은 시작일보다 빠를 수 없습니다.',
-    path: ['endDate'],
+  .superRefine((data, ctx) => {
+    const { status, startDate, endDate, publishedDate } = data;
+
+    if (status === READING_STATUS.WISH) {
+      if (startDate) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: '읽고 싶은 책은 시작일을 입력할 수 없습니다',
+          path: ['startDate'],
+        });
+      }
+      if (endDate) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: '읽고 싶은 책은 종료일을 입력할 수 없습니다',
+          path: ['endDate'],
+        });
+      }
+    }
+
+    if (
+      startDate &&
+      publishedDate &&
+      isAfterOrSameDate(publishedDate, startDate)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: '독서 시작일은 출판일 이후여야 합니다',
+        path: ['startDate'],
+      });
+    }
+
+    if (status === READING_STATUS.READING) {
+      if (!startDate) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: '읽는 중인 책은 시작일이 필수입니다',
+          path: ['startDate'],
+        });
+      }
+      return;
+    }
+
+    if (status === READING_STATUS.DONE) {
+      if (!startDate) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: '읽은 책은 시작일이 필수입니다',
+          path: ['startDate'],
+        });
+      }
+      if (!endDate) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: '읽은 책은 종료일이 필수입니다',
+          path: ['endDate'],
+        });
+      }
+
+      if (startDate && endDate && isAfterDate(startDate, endDate)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: '독서 시작일은 종료일보다 이전이어야 합니다',
+          path: ['endDate'],
+        });
+      }
+    }
+
+    if (status === READING_STATUS.PAUSE) {
+      if (!startDate) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: '보류 중인 책은 시작일이 필수입니다',
+          path: ['startDate'],
+        });
+      }
+    }
   });
-
-export const BOOK_FORM_DEFAULT_VALUES = {
-  title: '',
-  author: '',
-  publishedDate: undefined,
-  totalPages: 0,
-  status: READING_STATUS.WISH,
-  startDate: undefined,
-  endDate: undefined,
-  recommend: false,
-  rating: 0,
-  review: '',
-  quotes: [],
-  isPublic: false,
-} satisfies Partial<BookFormSchema>;
-
-export type BookFormSchema = z.infer<typeof bookFormSchema>;

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -7,7 +7,7 @@ export const BOOK_FORM_DEFAULT_VALUES = {
   title: '',
   author: '',
   publishedDate: '',
-  totalPages: 0,
+  totalPages: undefined,
   status: READING_STATUS.WISH,
   startDate: null,
   endDate: null,
@@ -28,8 +28,10 @@ export const bookFormSchema = z
     author: z.string().min(1, { message: '저자명을 입력해주세요.' }),
     publishedDate: dateSchema,
     totalPages: z.coerce
-      .number()
-      .min(1, { message: '전체 페이지 수를 입력해주세요.' }),
+      .number({
+        invalid_type_error: '숫자를 입력해주세요.',
+      })
+      .min(1, { message: '1 이상의 숫자를 입력해주세요.' }),
     status: z.enum(READING_STATUS_VALUES, {
       errorMap: () => ({ message: '독서 상태를 선택해주세요.' }),
     }),


### PR DESCRIPTION
## Overview

도서 기록 폼 기능 구현의 두번째와 세번째 단계로, “추천 & 별점 입력”, “독후감 작성” 섹션을 추가하고 전반적인 폼 흐름과 유효성 검증 로직을 완성했습니다. 

전체 폼 흐름을 step 쿼리 파라미터(?step={number}) 기반으로 제어하는 커스텀 훅들을 도입하여 확장성과 유지보수성을 확보했습니다.

linked-issue: #17 , #18 

## Preview [(보러가기)](https://multi-step-form-git-feat-issue-4-cff605-developerjhps-projects.vercel.app/?step=1)

<img width="1264" height="938" alt="image" src="https://github.com/user-attachments/assets/c2c13fff-019e-4b44-a9a4-0abfbadfbca4" />

<img width="1253" height="977" alt="image" src="https://github.com/user-attachments/assets/735aca8f-e717-4a31-b03a-70b68ed2bd16" />


## 설계 시 고려 사항

1.  각 폼 단계를 명시적으로 정의하고 구성
    * 기존처럼 {currentStep === 1 && <BookInfoStep />} 으로 하드코딩하지 않고, 각 단계를 객체(BOOK_FORM_STEPS)로 정의했습니다. (이름, 순서, 포함되는 필드들, 어떤 컴포넌트를 보여줄지까지 한 번에 정리)
    * 이렇게 하면 스텝 순서를 바꾸거나 필드를 추가할 때 변경이 용이하고, 전체 폼 구조를 한눈에 파악하기 쉽습니다.

2.  관심사 분리(SoC) 원칙에 기반한 커스텀 훅 설계
    * 복잡한 폼의 전체 흐름을 하나의 거대한 컴포넌트나 훅에서 관리하는 대신, 단일 책임 원칙(SRP)에 따라 기능별로 커스텀 훅을 설계했습니다.
      - `useUrlStep`: URL 쿼리 파라미터를 파싱하여 현재 스텝을 결정하는 역할만 담당합니다.
      - `useFormPersistence`: localStorage를 이용해 폼 상태를 저장하고 복원하는 역할만 담당합니다.
      - `useStepForm`: 위 훅들을 조합하여, 오직 폼의 스텝 이동과 제출 로직에만 집중하는 역할을 수행합니다.
      - 각 훅은 의존성을 외부에서 주입받도록 설계하여, 향후 프로젝트가 확장될 경우 어떤 폼이나 UI에서도 재사용할 수 있는 범용적인 훅으로 구현했습니다.

3.  사용자 관점에서 UX 설계
    * 에러 발생 시 단순히 메시지를 보여주는 것을 넘어, 문제가 발생한 필드로 포커스를 자동 이동시켜 사용자의 수고를 덜어주도록 구현했습니다.
    * useFormPersistence 훅을 통해, 사용자가 페이지를 새로고침하거나 실수로 창을 닫았다 다시 열어도 작성하던 내용을 잃지 않도록 하여 이탈을 방지했습니다.


## 주요 변경 사항

### Form
* `RatingStep` 및 `ReviewStep` 컴포넌트 구현
      - 독후감 : 100자 이상 조건부 필수 필드 + 실시간 카운트

* `useStepForm`, `useUrlStep`, `useFormPersistence` 훅 신규 구현  
      - URL 쿼리 기반 스텝 관리 로직 추상화
      - LocalStorage를 이용한 상태 복원 기능 구현 (새로고침 대응)
  
* BOOK_FORM_STEPS 상수 정의
      - 각 단계별 구성, 필드 목록, 렌더링 컴포넌트 연결
       
* RHFCommaSeparatedInput 컴포넌트 도입

### Validation (zod 스키마)
* 상태에 따른 startDate, endDate 필수 여부 검사
* 출판일 < 시작일 ≤ 종료일 조건
* 별점 1점 또는 5점인 경우 → 독후감 100자 이상 필수


### 향후 수정 포인트
1. QuotesStep, PublicStep은 현재 ReviewStep 컴포넌트를 임시로 재사용 중입니다. 추후 교체 필요합니다.


## Acceptance Criteria
* [x] 추천 여부와 별점을 입력할 수 있다.
* [x]  별점을 1점 또는 5점으로 선택하면, 독후감 100자 이상을 필수적으로 입력해야한다.
* [x] 독후감 글자 수가 실시간으로 표시된다.
* [x] 모든 필드는 유효성 검증이 적용된다. (추천여부 제외)
* [x] 입력 내용은 Preview에 반영된다.




close #17 
close #18 
