### PR TITLE
[Step 4 & 5] 인용구 및 공개 여부 설정 구현

### DIFF
--- a/src/components/form/steps/PublicStep.tsx
+++ b/src/components/form/steps/PublicStep.tsx
@@ -1,0 +1,182 @@
+import { useFormContext, Controller } from 'react-hook-form';
+import { RadioGroup, RadioItem } from '@/components/form/Radio';
+import Alert from '@/components/ui/Alert';
+import Icon from '@/components/ui/Icon';
+import styled from '@emotion/styled';
+import { css } from '@emotion/react';
+import { type BookFormSchema } from '@/utils/schema';
+import { BOOK_FORM_STEPS } from '@/constants/form';
+import { color } from '@/styles/colors';
+import { fontSize, fontWeight } from '@/styles/fonts';
+import AlertTriangleIcon from '@/assets/icons/alert-triangle.svg';
+
+const PRIVACY_OPTIONS = {
+  PUBLIC: 'true',
+  PRIVATE: 'false',
+} as const;
+
+export default function PublicStep() {
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext<BookFormSchema>();
+
+  const hasErrors = BOOK_FORM_STEPS.PUBLIC.fields.some(
+    (field) => errors[field],
+  );
+
+  return (
+    <Container>
+      {hasErrors && (
+        <Alert
+          variant="error"
+          title="입력 정보를 확인해주세요"
+          description="공개 설정을 선택해주세요."
+          icon={<Icon as={AlertTriangleIcon} size={20} />}
+        />
+      )}
+
+      <SectionHeader>
+        <SectionTitle>독서 기록을 공개하시겠습니까?</SectionTitle>
+        <SectionDescription>
+          공개로 설정하면 다른 사용자들이 회원님의 독서 기록을 볼 수 있습니다.
+          언제든지 설정에서 변경할 수 있습니다.
+        </SectionDescription>
+      </SectionHeader>
+
+      <FormSection>
+        <Controller
+          name="isPublic"
+          control={control}
+          render={({ field }) => (
+            <RadioGroup
+              name="isPublic"
+              value={
+                field.value ? PRIVACY_OPTIONS.PUBLIC : PRIVACY_OPTIONS.PRIVATE
+              }
+              onChange={(value) =>
+                field.onChange(value === PRIVACY_OPTIONS.PUBLIC)
+              }
+              direction="column"
+              errorMessage={errors.isPublic?.message}
+            >
+              <OptionContainer
+                variant="public"
+                onClick={() => field.onChange(true)}
+              >
+                <RadioItem value={PRIVACY_OPTIONS.PUBLIC} label="" />
+                <OptionContent>
+                  <OptionTitle>공개</OptionTitle>
+                  <OptionDescription>
+                    다른 사용자들이 내 독서 기록을 볼 수 있습니다. 독서
+                    커뮤니티에서 책에 대한 의견을 나누고 소통할 수 있습니다.
+                  </OptionDescription>
+                </OptionContent>
+              </OptionContainer>
+
+              <OptionContainer
+                variant="private"
+                onClick={() => field.onChange(false)}
+              >
+                <RadioItem value={PRIVACY_OPTIONS.PRIVATE} label="" />
+                <OptionContent>
+                  <OptionTitle>비공개</OptionTitle>
+                  <OptionDescription>
+                    내 독서 기록을 나만 볼 수 있습니다. 개인적인 독서 관리
+                    목적으로만 사용됩니다.
+                  </OptionDescription>
+                </OptionContent>
+              </OptionContainer>
+            </RadioGroup>
+          )}
+        />
+      </FormSection>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+`;
+
+const SectionHeader = styled.div`
+  text-align: center;
+`;
+
+const SectionTitle = styled.h2`
+  font-size: ${fontSize.xl};
+  font-weight: ${fontWeight.bold};
+  color: ${color.gray900};
+  margin: 0 0 1rem 0;
+`;
+
+const SectionDescription = styled.p`
+  font-size: ${fontSize.base};
+  color: ${color.gray600};
+  margin: 0;
+  line-height: 1.6;
+`;
+
+const FormSection = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const optionStyles = {
+  public: {
+    backgroundColor: color.green50,
+    borderColor: color.green200,
+    hoverBorderColor: color.green300,
+    hoverBackgroundColor: color.green100,
+  },
+  private: {
+    backgroundColor: color.gray50,
+    borderColor: color.gray200,
+    hoverBorderColor: color.gray300,
+    hoverBackgroundColor: color.gray100,
+  },
+};
+
+const OptionContainer = styled.div<{ variant: 'public' | 'private' }>`
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1.5rem;
+  border: 2px solid;
+  border-radius: 0.75rem;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+  width: 100%;
+  flex-grow: 1;
+  min-height: 120px;
+
+  ${({ variant }) => css`
+    background-color: ${optionStyles[variant].backgroundColor};
+    border-color: ${optionStyles[variant].borderColor};
+
+    &:hover {
+      border-color: ${optionStyles[variant].hoverBorderColor};
+      background-color: ${optionStyles[variant].hoverBackgroundColor};
+    }
+  `}
+`;
+
+const OptionContent = styled.div`
+  flex: 1;
+`;
+
+const OptionTitle = styled.h3`
+  font-size: ${fontSize.lg};
+  font-weight: ${fontWeight.semiBold};
+  color: ${color.gray900};
+  margin: 0 0 0.5rem 0;
+`;
+
+const OptionDescription = styled.p`
+  font-size: ${fontSize.sm};
+  color: ${color.gray600};
+  margin: 0;
+  line-height: 1.5;
+`;

--- a/src/components/form/steps/QuoteStep.tsx
+++ b/src/components/form/steps/QuoteStep.tsx
@@ -1,0 +1,227 @@
+import { useFormContext, Controller, useFieldArray } from 'react-hook-form';
+import RHFCommaSeparatedInput from '@/components/form/RHFCommaSeparatedInput';
+import TextArea from '@/components/ui/TextArea';
+import Button from '@/components/ui/Button';
+import Alert from '@/components/ui/Alert';
+import Icon from '@/components/ui/Icon';
+import styled from '@emotion/styled';
+import { type BookFormSchema } from '@/utils/schema';
+import { color } from '@/styles/colors';
+import { fontSize, fontWeight } from '@/styles/fonts';
+import AlertTriangleIcon from '@/assets/icons/alert-triangle.svg';
+
+export default function QuoteStep() {
+  const {
+    control,
+    watch,
+    formState: { errors },
+  } = useFormContext<BookFormSchema>();
+
+  const { fields, append, remove } = useFieldArray({
+    name: 'quotes',
+  });
+
+  const totalPages = watch('totalPages');
+  const quotes = watch('quotes') || [];
+
+  const hasMultipleQuotes = quotes.length >= 2;
+  const hasErrors = Boolean(errors.quotes);
+
+  const handleAddQuote = () => {
+    append({ text: '', pageNumber: undefined });
+  };
+
+  return (
+    <Container>
+      {hasErrors && (
+        <Alert
+          variant="error"
+          title="입력 정보를 확인해주세요"
+          description="인용구 정보를 올바르게 입력해주세요."
+          icon={<Icon as={AlertTriangleIcon} size={20} />}
+        />
+      )}
+
+      <SectionHeader>
+        <SectionTitle>인상 깊었던 구절을 인용해주세요</SectionTitle>
+        <SectionDescription>
+          기억에 남는 문장이나 구절을 자유롭게 추가해보세요.
+        </SectionDescription>
+      </SectionHeader>
+
+      <QuotesContainer>
+        {fields.length === 0 ? (
+          <EmptyState>
+            <EmptyMessage>아직 추가된 인용구가 없습니다.</EmptyMessage>
+            <Button type="button" variant="blue" onClick={handleAddQuote}>
+              첫 번째 인용구 추가
+            </Button>
+          </EmptyState>
+        ) : (
+          <>
+            {fields.map((field, index) => (
+              <QuoteItem key={field.id}>
+                <QuoteHeader>
+                  <QuoteNumber>인용구 {index + 1}</QuoteNumber>
+                  <Button
+                    type="button"
+                    variant="red"
+                    onClick={() => remove(index)}
+                  >
+                    삭제
+                  </Button>
+                </QuoteHeader>
+
+                <Controller
+                  name={`quotes.${index}.text`}
+                  control={control}
+                  render={({ field }) => (
+                    <TextAreaContainer>
+                      <TextArea
+                        {...field}
+                        placeholder="인상 깊었던 구절을 입력해주세요"
+                        rows={4}
+                        hasError={Boolean(errors.quotes?.[index]?.text)}
+                      />
+                      {errors.quotes?.[index]?.text && (
+                        <ErrorMessage>
+                          {errors.quotes[index]?.text?.message}
+                        </ErrorMessage>
+                      )}
+                    </TextAreaContainer>
+                  )}
+                />
+
+                <RHFCommaSeparatedInput
+                  id={`quote-page-${index}`}
+                  name={`quotes.${index}.pageNumber`}
+                  control={control}
+                  label="페이지 번호"
+                  placeholder="페이지 번호를 입력해주세요"
+                  required={hasMultipleQuotes}
+                />
+              </QuoteItem>
+            ))}
+
+            <AddQuoteButton
+              type="button"
+              variant="secondary"
+              onClick={handleAddQuote}
+            >
+              인용구 추가
+            </AddQuoteButton>
+          </>
+        )}
+      </QuotesContainer>
+
+      {hasMultipleQuotes && (
+        <ValidationInfo>
+          <InfoIcon as={AlertTriangleIcon} size={16} />
+          인용구가 2개 이상인 경우 페이지 번호는 필수입니다.
+          {totalPages && ` (1~${totalPages} 페이지)`}
+        </ValidationInfo>
+      )}
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+`;
+
+const SectionHeader = styled.div`
+  text-align: center;
+`;
+
+const SectionTitle = styled.h2`
+  font-size: ${fontSize.xl};
+  font-weight: ${fontWeight.bold};
+  color: ${color.gray900};
+  margin: 0 0 0.5rem 0;
+`;
+
+const SectionDescription = styled.p`
+  font-size: ${fontSize.base};
+  color: ${color.gray600};
+  margin: 0;
+`;
+
+const QuotesContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+`;
+
+const EmptyState = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 3rem 1rem;
+  background-color: ${color.gray50};
+  border-radius: 0.75rem;
+  border: 2px dashed ${color.gray300};
+`;
+
+const EmptyMessage = styled.p`
+  font-size: ${fontSize.base};
+  color: ${color.gray500};
+  margin: 0;
+`;
+
+const QuoteItem = styled.div`
+  padding: 1.5rem;
+  background-color: ${color.white};
+  border: 1px solid ${color.gray200};
+  border-radius: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+const QuoteHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const QuoteNumber = styled.h3`
+  font-size: ${fontSize.lg};
+  font-weight: ${fontWeight.semiBold};
+  color: ${color.gray900};
+  margin: 0;
+`;
+
+const TextAreaContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const AddQuoteButton = styled(Button)`
+  align-self: flex-start;
+`;
+
+const ValidationInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem;
+  background-color: ${color.blue50};
+  border: 1px solid ${color.blue200};
+  border-radius: 0.5rem;
+  font-size: ${fontSize.sm};
+  color: ${color.blue700};
+`;
+
+const InfoIcon = styled(Icon)`
+  color: ${color.blue500};
+  flex-shrink: 0;
+`;
+
+const ErrorMessage = styled.p`
+  font-size: ${fontSize.sm};
+  color: ${color.red500};
+  margin: 0.25rem 0 0 0;
+`;

--- a/src/components/preview/AppPreview.tsx
+++ b/src/components/preview/AppPreview.tsx
@@ -37,6 +37,7 @@ export function AppPreview({ bookInfo }: AppPreviewProps) {
     recommend,
     rating,
     review,
+    quotes,
   } = debouncedBookInfo;
 
   return (
@@ -49,7 +50,7 @@ export function AppPreview({ bookInfo }: AppPreviewProps) {
           <DateSection startDate={startDate} endDate={endDate} />
           <RatingSection recommend={recommend} rating={rating} />
           <ReviewSection review={review} />
-          <QuoteSection />
+          <QuoteSection quotes={quotes} />
           <PrivacySection isPublic={isPublic} />
         </ScrollContent>
         <ActionButtons />

--- a/src/components/preview/sections/DateSection.tsx
+++ b/src/components/preview/sections/DateSection.tsx
@@ -13,6 +13,10 @@ interface DateSectionProps {
 }
 
 export function DateSection({ startDate, endDate }: DateSectionProps) {
+  if (startDate == null) {
+    return null;
+  }
+
   return (
     <Section>
       <SectionTitle>

--- a/src/components/preview/sections/QuoteSection.tsx
+++ b/src/components/preview/sections/QuoteSection.tsx
@@ -2,15 +2,25 @@ import styled from '@emotion/styled';
 import { color } from '@/styles/colors';
 import { spacing } from '@/styles/spacing';
 import { borderRadius } from '@/styles/border-radius';
+import { fontSize, fontWeight } from '@/styles/fonts';
 import Icon from '@/components/ui/Icon';
 import Quote from '@/assets/icons/quote.svg';
+import { type BookFormSchema } from '@/utils/schema';
 import {
   Section,
   SectionTitle,
   PlaceholderText,
 } from '@/components/preview/styles/shared';
 
-export function QuoteSection() {
+interface QuoteSectionProps {
+  quotes: BookFormSchema['quotes'];
+}
+
+export function QuoteSection({ quotes }: QuoteSectionProps) {
+  if (quotes == null || quotes.length === 0) {
+    return null;
+  }
+
   return (
     <Section>
       <SectionTitle>
@@ -18,9 +28,24 @@ export function QuoteSection() {
         인상 깊은 구절
       </SectionTitle>
       <QuotesContainer>
-        <QuotePlaceholder>
-          <PlaceholderText>인상 깊은 구절을 추가해주세요...</PlaceholderText>
-        </QuotePlaceholder>
+        {quotes.length === 0 ? (
+          <QuotePlaceholder>
+            <PlaceholderText>인상 깊은 구절을 추가해주세요...</PlaceholderText>
+          </QuotePlaceholder>
+        ) : (
+          quotes.map((quote, index) => (
+            <QuoteItem key={index}>
+              <QuoteText>&quot;{quote.text}&quot;</QuoteText>
+              {quote.pageNumber && (
+                <QuotePageNumber>
+                  {Array.isArray(quote.pageNumber)
+                    ? quote.pageNumber.join(', ') + '페이지'
+                    : quote.pageNumber + '페이지'}
+                </QuotePageNumber>
+              )}
+            </QuoteItem>
+          ))
+        )}
       </QuotesContainer>
     </Section>
   );
@@ -37,4 +62,27 @@ const QuotePlaceholder = styled.div`
   border-radius: ${borderRadius.lg};
   padding: ${spacing[3]};
   border-left: 4px solid ${color.gray300};
+`;
+
+const QuoteItem = styled.div`
+  background: ${color.white};
+  border-radius: ${borderRadius.lg};
+  padding: ${spacing[4]};
+  border-left: 4px solid ${color.blue500};
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+`;
+
+const QuoteText = styled.p`
+  font-size: ${fontSize.base};
+  font-weight: ${fontWeight.medium};
+  color: ${color.gray800};
+  line-height: 1.6;
+  margin: 0 0 ${spacing[2]} 0;
+  font-style: italic;
+`;
+
+const QuotePageNumber = styled.span`
+  font-size: ${fontSize.sm};
+  color: ${color.gray500};
+  font-weight: ${fontWeight.regular};
 `;

--- a/src/constants/form.ts
+++ b/src/constants/form.ts
@@ -1,6 +1,8 @@
 import BookInfoStep from '@/components/form/steps/BookInfoStep';
 import RatingStep from '@/components/form/steps/RatingStep';
 import ReviewStep from '@/components/form/steps/ReviewStep';
+import QuoteStep from '@/components/form/steps/QuoteStep';
+import PublicStep from '@/components/form/steps/PublicStep';
 
 export const BOOK_FORM_STEPS = {
   BOOK_INFO: {
@@ -33,12 +35,12 @@ export const BOOK_FORM_STEPS = {
     order: 4,
     label: '인용구',
     fields: ['quotes'],
-    component: ReviewStep, // FIXME: QuoteStep으로 교체 필요
+    component: QuoteStep,
   },
   PUBLIC: {
     order: 5,
     label: '공개 설정',
     fields: ['isPublic'],
-    component: ReviewStep, // FIXME: PublicStep으로 교체 필요
+    component: PublicStep,
   },
 } as const;

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -41,8 +41,18 @@ export const bookFormSchema = z
     recommend: z.boolean({ required_error: '추천 여부를 선택해주세요.' }),
     rating: z.number().min(0.5, { message: '별점을 선택해주세요.' }).max(5),
     review: z.string().optional(),
-    quotes: z.array(z.string()).optional(),
-    isPublic: z.boolean().optional(),
+    quotes: z
+      .array(
+        z.object({
+          text: z.string().min(1, { message: '인용구 내용을 입력해주세요.' }),
+          pageNumber: z.coerce
+            .number()
+            .min(1, { message: '1 이상의 페이지 번호를 입력해주세요.' })
+            .optional(),
+        }),
+      )
+      .optional(),
+    isPublic: z.boolean({ required_error: '공개 설정을 선택해주세요.' }),
   })
   .superRefine((data, ctx) => {
     const {
@@ -53,6 +63,7 @@ export const bookFormSchema = z
       rating,
       review,
       totalPages,
+      quotes,
     } = data;
 
     if (totalPages === undefined) {
@@ -143,6 +154,30 @@ export const bookFormSchema = z
         code: z.ZodIssueCode.custom,
         message: '별점이 1점 또는 5점인 경우 독후감을 100자 이상 입력해주세요.',
         path: ['review'],
+      });
+    }
+
+    if (quotes && quotes.length > 0) {
+      const hasMultipleQuotes = quotes.length >= 2;
+
+      quotes.forEach((quote, index) => {
+        if (quote.pageNumber !== undefined) {
+          if (totalPages !== undefined && quote.pageNumber > totalPages) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: `페이지 번호는 전체 페이지 수(${totalPages}) 이하여야 합니다.`,
+              path: ['quotes', index, 'pageNumber'],
+            });
+          }
+        }
+
+        if (hasMultipleQuotes && quote.pageNumber === undefined) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: '인용구가 2개 이상인 경우 페이지 번호는 필수입니다.',
+            path: ['quotes', index, 'pageNumber'],
+          });
+        }
       });
     }
   });


### PR DESCRIPTION
## Overview

도서 기록 폼 기능 구현의 네 번째와 다섯 번째 단계로, **“인용구 입력”** 및 **“공개 여부 설정”** 섹션을 추가하였으며, 전체 폼 흐름 및 미리보기 반영까지 마무리되었습니다. 
이로써 폼의 전반적인 단계 구성과 핵심 기능이 완성되었습니다.  
(다음 단계로  제출한 도서 정보를 볼 수 있는 리스트와,  msw/react-query를 사용하여 도서제목 입력시 추천목록이 뜨는 기능을 구현할 예정입니다.)

linked-issue: #19, #20

## Preview [(보러가기)](https://multi-step-form-git-feat-issue-6-db1bc9-developerjhps-projects.vercel.app/?step=1)

<img width="1268" height="912" alt="image" src="https://github.com/user-attachments/assets/86fd80b1-f7f4-4731-8f04-f3e04b4c17a0" />

<img width="1206" height="929" alt="image" src="https://github.com/user-attachments/assets/20d8802e-60f4-47b9-a53c-74259375d2a6" />

---

## 주요 변경 사항

### Form

* `QuoteStep` 컴포넌트 구현

  * `react-hook-form` + `useFieldArray` 기반 인용구 입력 UI 구현
  * 페이지 번호는 comma-separated로 입력 가능 (`RHFCommaSeparatedInput` 재사용)

* `PublicStep` 컴포넌트 구현

  * `RadioGroup` 기반 공개 여부 UI 구현
  * 선택하지 않을 경우 에러 메시지 제공

* `BOOK_FORM_STEPS` 상수에 해당 스텝 정보 추가

### Validation (`zod` 스키마)

* `quotes`는 배열 형태로 구조화되며, 각 인용구는 `text` 필수, `pageNumber` 선택
* **2개 이상 인용구 입력 시, 각 인용구에 페이지 번호 필수**
* `pageNumber`가 `totalPages`를 초과하지 않도록 검증 로직 추가


## Acceptance Criteria

* [x] 인상 깊었던 구절을 자유롭게 추가할 수 있다.
* [x] 인용구가 2개 이상일 경우 페이지 번호를 필수로 입력해야 한다.
* [x] 공개 여부를 명확하게 선택할 수 있으며, 미선택 시 에러가 발생한다.
* [x] 인용구 및 공개 여부는 Preview 화면에 반영된다.
* [x] 모든 입력 필드는 유효성 검증이 적용된다.

close #19
close #20